### PR TITLE
Change directory separators in weather plugin config

### DIFF
--- a/_assets_/plugins/revizeWeather/main.php
+++ b/_assets_/plugins/revizeWeather/main.php
@@ -1,7 +1,7 @@
 <?php
 // error_reporting(E_ALL);ini_set('display_errors', 1);
-require_once __DIR__."\class\OpenWeatherMapWidget.php";
-require_once __DIR__."\config.php";
+require_once __DIR__."/class/OpenWeatherMapWidget.php";
+require_once __DIR__."/config.php";
 header('Content-Type: application/json');
 
 /******************


### PR DESCRIPTION
Update directory path from backslashes to forward slashes, to fix a bug when trying to use the weather plugin on Unix systems.