### PR TITLE
Add Alert Box Close Cache

### DIFF
--- a/_assets_/js/scripts.js
+++ b/_assets_/js/scripts.js
@@ -244,6 +244,21 @@
 	});
 	// End Frame Resizer
 
+	// Alert Close Caching
+	if ($("div.alert").length) {
+		if (window.sessionStorage) {
+			var hide = parseInt(window.sessionStorage.getItem("alertClosed")) > 1;
+			if (hide && $(".user-logged-in").length == 0) {
+				$("div.alert").slideToggle();
+			}
+		}
+		$("div.alert button.close").on('click', function(e) {
+			if (window.sessionStorage) {
+				window.sessionStorage.setItem("alertClosed",parseInt(window.sessionStorage.getItem("alertClosed")||0)+1);
+			}
+		});
+	}
+	
 	// revizeWeather
 	if( typeof $.fn.revizeWeather !== "undefined" ){
 		$.fn.revizeWeather({


### PR DESCRIPTION
After 2 closes in the same window session, the alert box will remain hidden. The exception is that if the user is logged into the Revize backend, the alert will remain open as most enablers are now placing the edit button within the Alert box.