### PR TITLE
Fix Datatables Mobile View Pagination

### DIFF
--- a/_assets_/js/DT_bootstrap2.js
+++ b/_assets_/js/DT_bootstrap2.js
@@ -76,6 +76,8 @@
 										e.preventDefault();
 										oSettings._iDisplayStart = (parseInt($('a', this).text(),10)-1) * oPaging.iLength;
 										fnDraw( oSettings );
+										$(".stacktable.small-only").remove();
+										$("#example").stacktable();
 									} );
 							}
 			


### PR DESCRIPTION
Using the numerical pagination was being prevented by line 75; Add stack tables refresh here as well.